### PR TITLE
.dockstore.yml: Change relative file paths to absolute paths for Dockstore 1.15

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -3,7 +3,7 @@ workflows:
   - name: get_random_intervals
     subclass: WDL
     description: Given a BAM, use the header information and some parameters to generate random BED intervals
-    primaryDescriptorPath: get_random_intervals.wdl
+    primaryDescriptorPath: /get_random_intervals.wdl
     testParameterFiles:
     authors:
       - name: Ryan Lorig-Roach
@@ -11,7 +11,7 @@ workflows:
   - name: merge_samples_by_intervals
     subclass: WDL
     description: Given a set of intervals and a set of BAM files, create a merged (across BAMS) output for each interval
-    primaryDescriptorPath: merge_samples_by_intervals.wdl
+    primaryDescriptorPath: /merge_samples_by_intervals.wdl
     testParameterFiles:
     authors:
       - name: Ryan Lorig-Roach
@@ -19,7 +19,7 @@ workflows:
   - name: profile_dbg
     subclass: WDL
     description: Given a set of tarballs containing Fastas and coverage Tsv, create an equivalently sized set of outputs and resource logs for each tool specified
-    primaryDescriptorPath: profile_dbg.wdl
+    primaryDescriptorPath: /profile_dbg.wdl
     testParameterFiles:
     authors:
       - name: Ryan Lorig-Roach
@@ -27,7 +27,7 @@ workflows:
   - name: convert_ggcat_fasta_to_gfa
     subclass: WDL
     description: Given a set of fastas produced by ggcat, using tags with the BCALM link format, convert to a GFAs
-    primaryDescriptorPath: convert_ggcat_fasta_to_gfa.wdl
+    primaryDescriptorPath: /convert_ggcat_fasta_to_gfa.wdl
     testParameterFiles:
     authors:
       - name: Ryan Lorig-Roach


### PR DESCRIPTION
Hello,
I am a software developer at Dockstore and we are approaching our 1.15 release.

Prior to this release, relative paths were being inconsistently and unreliably processed in various parts of our system.
Therefore, in this release, we have more explicitly deprecated the use of relative file paths in our `.dockstore.yml` so all workflows with relative paths will now be deemed as invalid.
Thus, I have created this PR to change the file paths to absolute paths such that your workflows will still be valid after our release.

If you have any questions, please feel free to comment below.

Thank you!
Nayeon - Dockstore